### PR TITLE
Unify configuration UI and schedule-aware tray menu

### DIFF
--- a/src/momo/app.py
+++ b/src/momo/app.py
@@ -65,7 +65,7 @@ class MoMoApp:
         self._tray_icon.set_autostart(autostart_enabled)
         self._tray_icon.set_threshold(self._settings.idle_threshold_seconds)
         self._tray_icon.set_monitoring(self._settings.monitoring_enabled)
-        self._update_schedule_state()
+        self._update_schedule_state(apply_monitoring=False)
     
     def _setup_callbacks(self):
         """Set up callbacks between components."""
@@ -191,11 +191,11 @@ class MoMoApp:
             return f"Schedule: {day_name} disabled"
         return f"Schedule: {day_name} {day_schedule.start_time}–{day_schedule.stop_time}"
 
-    def _update_schedule_state(self) -> None:
+    def _update_schedule_state(self, apply_monitoring: bool = True) -> None:
         within_schedule = self._schedule_manager.is_within_schedule()
         schedule_label = self._get_schedule_label()
         self._tray_icon.set_schedule_status(within_schedule, schedule_label)
-        if self._running:
+        if apply_monitoring and self._running:
             self._apply_monitoring_state(within_schedule)
 
     def _schedule_tick(self) -> None:

--- a/src/momo/app.py
+++ b/src/momo/app.py
@@ -12,6 +12,7 @@ The main entry point that coordinates all components:
 
 import sys
 import threading
+from datetime import datetime
 from typing import Optional
 
 from .idle_detector import IdleDetector
@@ -20,7 +21,7 @@ from .settings import SettingsManager
 from .schedule import ScheduleManager
 from .tray_icon import TrayIcon
 from .autostart import AutoStartManager
-from .dialogs import show_threshold_dialog, show_schedule_dialog, show_error
+from .dialogs import show_configuration_dialog, show_error
 
 
 class MoMoApp:
@@ -46,6 +47,8 @@ class MoMoApp:
         self._running = False
         self._is_moving = False
         self._active_icon_timer: Optional[threading.Timer] = None
+        self._schedule_timer: Optional[threading.Timer] = None
+        self._schedule_refresh_interval = 60.0
         
         # Set up callbacks
         self._setup_callbacks()
@@ -62,6 +65,7 @@ class MoMoApp:
         self._tray_icon.set_autostart(autostart_enabled)
         self._tray_icon.set_threshold(self._settings.idle_threshold_seconds)
         self._tray_icon.set_monitoring(self._settings.monitoring_enabled)
+        self._update_schedule_state()
     
     def _setup_callbacks(self):
         """Set up callbacks between components."""
@@ -74,9 +78,7 @@ class MoMoApp:
         
         # Tray icon callbacks
         self._tray_icon.set_on_start_stop(self._on_monitoring_toggled)
-        self._tray_icon.set_on_configure_threshold(self._on_configure_threshold)
-        self._tray_icon.set_on_configure_schedule(self._on_configure_schedule)
-        self._tray_icon.set_on_toggle_autostart(self._on_autostart_toggled)
+        self._tray_icon.set_on_configure(self._on_configure)
         self._tray_icon.set_on_exit(self._on_exit)
     
     def _on_idle_detected(self):
@@ -129,58 +131,80 @@ class MoMoApp:
                 "Settings Error",
                 "Failed to save monitoring setting. Changes may not persist."
             )
-        
-        if is_enabled:
+        self._tray_icon.set_monitoring(is_enabled)
+        self._apply_monitoring_state()
+    
+    def _on_configure(self):
+        """Called when unified configuration is requested."""
+        current_autostart = self._autostart_manager.is_enabled()
+        result = show_configuration_dialog(self._settings, current_autostart)
+
+        if result is None:
+            return
+
+        desired_autostart = result.auto_start
+        if desired_autostart != current_autostart:
+            success = self._autostart_manager.set_enabled(desired_autostart)
+            if not success:
+                show_error(
+                    "Auto-Start Error",
+                    "Failed to update auto-start setting. Please try again."
+                )
+                desired_autostart = current_autostart
+
+        self._settings.idle_threshold_seconds = result.idle_threshold_seconds
+        self._settings.schedule = result.schedule
+        self._settings.auto_start = desired_autostart
+
+        self._idle_detector.threshold_seconds = result.idle_threshold_seconds
+        self._schedule_manager.schedule = result.schedule
+
+        self._tray_icon.set_autostart(desired_autostart)
+        self._tray_icon.set_threshold(result.idle_threshold_seconds)
+        self._tray_icon.set_monitoring(self._settings.monitoring_enabled)
+        self._update_schedule_state()
+
+        if not self._settings_manager.save():
+            show_error(
+                "Settings Error",
+                "Failed to save configuration. Changes may not persist."
+            )
+
+    def _apply_monitoring_state(self, within_schedule: Optional[bool] = None) -> None:
+        """Start or stop monitoring based on user and schedule state."""
+        if within_schedule is None:
+            within_schedule = self._schedule_manager.is_within_schedule()
+        should_monitor = self._settings.monitoring_enabled and within_schedule
+
+        if should_monitor:
             self._idle_detector.start_monitoring()
         else:
             self._idle_detector.stop_monitoring()
-    
-    def _on_configure_threshold(self):
-        """Called when threshold configuration is requested."""
-        result = show_threshold_dialog(self._settings.idle_threshold_seconds)
-        
-        if result is not None:
-            self._settings.idle_threshold_seconds = result
-            self._idle_detector.threshold_seconds = result
-            if not self._settings_manager.save():
-                show_error(
-                    "Settings Error",
-                    "Failed to save idle threshold. Changes may not persist."
-                )
-            self._tray_icon.set_threshold(result)
-    
-    def _on_configure_schedule(self):
-        """Called when schedule configuration is requested."""
-        result = show_schedule_dialog(self._settings.schedule)
-        
-        if result is not None:
-            self._settings.schedule = result
-            self._schedule_manager.schedule = result
-            if not self._settings_manager.save():
-                show_error(
-                    "Settings Error",
-                    "Failed to save schedule. Changes may not persist."
-                )
-    
-    def _on_autostart_toggled(self, is_enabled: bool):
-        """Called when autostart is toggled from tray menu."""
-        success = self._autostart_manager.set_enabled(is_enabled)
-        
-        if success:
-            self._settings.auto_start = is_enabled
-            if not self._settings_manager.save():
-                show_error(
-                    "Settings Error",
-                    "Failed to save auto-start setting. Changes may not persist."
-                )
-            self._tray_icon.set_autostart(is_enabled)
-        else:
-            # Revert the UI state if failed
-            self._tray_icon.set_autostart(not is_enabled)
-            show_error(
-                "Auto-Start Error",
-                "Failed to update auto-start setting. Please try again."
-            )
+
+    def _get_schedule_label(self) -> str:
+        """Return a schedule label for the tray menu."""
+        day_index = datetime.now().weekday()
+        day_name = self._schedule_manager.get_day_name(day_index)
+        day_schedule = self._schedule_manager.get_current_day_schedule()
+
+        if not day_schedule.enabled:
+            return f"Schedule: {day_name} disabled"
+        return f"Schedule: {day_name} {day_schedule.start_time}–{day_schedule.stop_time}"
+
+    def _update_schedule_state(self) -> None:
+        within_schedule = self._schedule_manager.is_within_schedule()
+        schedule_label = self._get_schedule_label()
+        self._tray_icon.set_schedule_status(within_schedule, schedule_label)
+        if self._running:
+            self._apply_monitoring_state(within_schedule)
+
+    def _schedule_tick(self) -> None:
+        if not self._running:
+            return
+        self._update_schedule_state()
+        self._schedule_timer = threading.Timer(self._schedule_refresh_interval, self._schedule_tick)
+        self._schedule_timer.daemon = True
+        self._schedule_timer.start()
     
     def _on_exit(self):
         """Called when exit is requested from tray menu."""
@@ -197,10 +221,10 @@ class MoMoApp:
         and runs the event loop.
         """
         self._running = True
-        
-        # Start monitoring if enabled in settings
-        if self._settings.monitoring_enabled:
-            self._idle_detector.start_monitoring()
+        self._update_schedule_state()
+        self._schedule_timer = threading.Timer(self._schedule_refresh_interval, self._schedule_tick)
+        self._schedule_timer.daemon = True
+        self._schedule_timer.start()
         
         try:
             # Run the tray icon (blocking)
@@ -220,6 +244,8 @@ class MoMoApp:
         # Cancel any pending timers
         if self._active_icon_timer:
             self._active_icon_timer.cancel()
+        if self._schedule_timer:
+            self._schedule_timer.cancel()
         
         # Stop the tray icon
         self._tray_icon.stop()

--- a/src/momo/dialogs.py
+++ b/src/momo/dialogs.py
@@ -59,6 +59,7 @@ class ConfigurationDialog:
         try:
             style.theme_use('clam')
         except tk.TclError:
+            # If the 'clam' theme is not available, fall back to default.
             pass
 
         style.configure('Header.TLabel', font=('Segoe UI', 14, 'bold'))

--- a/src/momo/dialogs.py
+++ b/src/momo/dialogs.py
@@ -9,10 +9,260 @@ thread marshalling when called from pystray callbacks.
 """
 
 import tkinter as tk
-from tkinter import messagebox
+from tkinter import messagebox, ttk
 from typing import Optional
 import threading
 from .settings import Settings, WeeklySchedule, DaySchedule
+
+
+class ConfigurationDialog:
+    """Unified configuration dialog for MoMo settings."""
+
+    DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
+
+    def __init__(
+        self,
+        parent: Optional[tk.Tk] = None,
+        settings: Optional[Settings] = None,
+        autostart_enabled: bool = False,
+    ):
+        self._settings = settings or Settings()
+        self._result: Optional[Settings] = None
+
+        if parent:
+            self._dialog = tk.Toplevel(parent)
+        else:
+            self._dialog = tk.Tk()
+
+        self._dialog.title("MoMo - Mouse Mover")
+        self._dialog.resizable(False, False)
+        self._dialog.geometry("720x560")
+        self._dialog.attributes('-topmost', True)
+        self._dialog.protocol("WM_DELETE_WINDOW", self._on_cancel)
+
+        self._autostart_var = tk.BooleanVar(value=autostart_enabled)
+        self._threshold_var = tk.StringVar(value=str(self._settings.idle_threshold_seconds))
+
+        self._day_vars = {}
+        self._start_vars = {}
+        self._end_vars = {}
+
+        self._apply_style()
+        self._create_widgets()
+        self._center_window()
+
+        self._dialog.focus_force()
+        self._dialog.lift()
+
+    def _apply_style(self) -> None:
+        style = ttk.Style()
+        try:
+            style.theme_use('clam')
+        except tk.TclError:
+            pass
+
+        style.configure('Header.TLabel', font=('Segoe UI', 14, 'bold'))
+        style.configure('Subheader.TLabel', font=('Segoe UI', 10), foreground='#666666')
+        style.configure('Section.TLabelframe', padding=(12, 8))
+        style.configure('Section.TLabelframe.Label', font=('Segoe UI', 10, 'bold'))
+        style.configure('Primary.TButton', font=('Segoe UI', 10, 'bold'))
+
+    def _center_window(self) -> None:
+        self._dialog.update_idletasks()
+        width = 720
+        height = 560
+        x = (self._dialog.winfo_screenwidth() // 2) - (width // 2)
+        y = (self._dialog.winfo_screenheight() // 2) - (height // 2)
+        self._dialog.geometry(f'{width}x{height}+{x}+{y}')
+
+    def _create_widgets(self) -> None:
+        container = ttk.Frame(self._dialog, padding=20)
+        container.pack(fill=tk.BOTH, expand=True)
+
+        header = ttk.Label(container, text="MoMo - Mouse Mover", style='Header.TLabel')
+        header.pack(anchor=tk.W)
+        subheader = ttk.Label(
+            container,
+            text="Configure idle threshold, schedule, and startup behavior.",
+            style='Subheader.TLabel'
+        )
+        subheader.pack(anchor=tk.W, pady=(2, 14))
+
+        notebook = ttk.Notebook(container)
+        notebook.pack(fill=tk.BOTH, expand=True)
+
+        general_tab = ttk.Frame(notebook, padding=12)
+        schedule_tab = ttk.Frame(notebook, padding=12)
+        notebook.add(general_tab, text="General")
+        notebook.add(schedule_tab, text="Schedule")
+
+        general_group = ttk.LabelFrame(general_tab, text="Idle Detection", style='Section.TLabelframe')
+        general_group.pack(fill=tk.X, pady=(0, 12))
+
+        ttk.Label(general_group, text="Idle threshold (seconds):").grid(row=0, column=0, sticky=tk.W)
+        threshold_entry = ttk.Entry(general_group, textvariable=self._threshold_var, width=12)
+        threshold_entry.grid(row=0, column=1, sticky=tk.W, padx=(10, 0))
+        ttk.Label(
+            general_group,
+            text="Move the mouse after this many seconds of inactivity.",
+            foreground='#666666'
+        ).grid(row=1, column=0, columnspan=2, sticky=tk.W, pady=(4, 0))
+
+        startup_group = ttk.LabelFrame(general_tab, text="Startup", style='Section.TLabelframe')
+        startup_group.pack(fill=tk.X)
+
+        ttk.Checkbutton(
+            startup_group,
+            text="Start with Windows",
+            variable=self._autostart_var
+        ).pack(anchor=tk.W)
+        ttk.Label(
+            startup_group,
+            text="Enable this to launch MoMo when you sign in.",
+            foreground='#666666'
+        ).pack(anchor=tk.W, pady=(4, 0))
+
+        self._build_schedule_tab(schedule_tab)
+
+        button_row = ttk.Frame(container)
+        button_row.pack(fill=tk.X, pady=(12, 0))
+
+        reset_button = ttk.Button(button_row, text="Reset Schedule", command=self._on_reset)
+        reset_button.pack(side=tk.LEFT)
+
+        cancel_button = ttk.Button(button_row, text="Cancel", command=self._on_cancel)
+        cancel_button.pack(side=tk.RIGHT, padx=(8, 0))
+
+        ok_button = ttk.Button(button_row, text="Save", style='Primary.TButton', command=self._on_ok)
+        ok_button.pack(side=tk.RIGHT)
+
+        self._dialog.bind('<Return>', lambda e: self._on_ok())
+        self._dialog.bind('<Escape>', lambda e: self._on_cancel())
+
+    def _build_schedule_tab(self, parent: ttk.Frame) -> None:
+        schedule_group = ttk.LabelFrame(parent, text="Active Schedule", style='Section.TLabelframe')
+        schedule_group.pack(fill=tk.BOTH, expand=True)
+
+        ttk.Label(
+            schedule_group,
+            text="MoMo will only move the mouse during the scheduled times.",
+            foreground='#666666'
+        ).pack(anchor=tk.W, pady=(0, 10))
+
+        grid = ttk.Frame(schedule_group)
+        grid.pack(fill=tk.X)
+
+        ttk.Label(grid, text="Day", width=12).grid(row=0, column=0, sticky=tk.W, padx=(0, 8))
+        ttk.Label(grid, text="Enabled", width=8).grid(row=0, column=1, padx=5)
+        ttk.Label(grid, text="Start", width=10).grid(row=0, column=2, padx=5)
+        ttk.Label(grid, text="End", width=10).grid(row=0, column=3, padx=5)
+
+        for i, day in enumerate(self.DAYS):
+            day_schedule = self._settings.schedule.get_day(i)
+
+            ttk.Label(grid, text=day, width=12).grid(row=i + 1, column=0, sticky=tk.W, pady=4, padx=(0, 8))
+
+            enabled_var = tk.BooleanVar(value=day_schedule.enabled)
+            self._day_vars[i] = enabled_var
+            ttk.Checkbutton(grid, variable=enabled_var).grid(row=i + 1, column=1, pady=4)
+
+            start_var = tk.StringVar(value=day_schedule.start_time)
+            self._start_vars[i] = start_var
+            ttk.Entry(grid, textvariable=start_var, width=8).grid(row=i + 1, column=2, padx=5, pady=4)
+
+            end_var = tk.StringVar(value=day_schedule.stop_time)
+            self._end_vars[i] = end_var
+            ttk.Entry(grid, textvariable=end_var, width=8).grid(row=i + 1, column=3, padx=5, pady=4)
+
+        ttk.Label(
+            schedule_group,
+            text="Times use 24-hour format (HH:MM). Example: 08:00, 17:00",
+            foreground='#666666'
+        ).pack(anchor=tk.W, pady=(10, 0))
+
+    def _validate_time(self, time_str: str) -> bool:
+        try:
+            if not isinstance(time_str, str):
+                return False
+            parts = time_str.split(':')
+            if len(parts) != 2:
+                return False
+            hours_str, minutes_str = parts[0], parts[1]
+            if len(hours_str) != 2 or len(minutes_str) != 2:
+                return False
+            if not (hours_str.isdigit() and minutes_str.isdigit()):
+                return False
+            hours = int(hours_str)
+            minutes = int(minutes_str)
+            return 0 <= hours <= 23 and 0 <= minutes <= 59
+        except (ValueError, AttributeError):
+            return False
+
+    def _on_ok(self) -> None:
+        try:
+            threshold_value = int(self._threshold_var.get())
+            if threshold_value <= 0:
+                raise ValueError
+        except ValueError:
+            messagebox.showerror(
+                "Invalid Value",
+                "Please enter a positive integer for the idle threshold.",
+                parent=self._dialog
+            )
+            return
+
+        for i in range(7):
+            start = self._start_vars[i].get()
+            end = self._end_vars[i].get()
+
+            if not self._validate_time(start):
+                messagebox.showerror(
+                    "Invalid Time",
+                    f"Invalid start time for {self.DAYS[i]}. Use HH:MM format.",
+                    parent=self._dialog
+                )
+                return
+
+            if not self._validate_time(end):
+                messagebox.showerror(
+                    "Invalid Time",
+                    f"Invalid end time for {self.DAYS[i]}. Use HH:MM format.",
+                    parent=self._dialog
+                )
+                return
+
+        updated_schedule = WeeklySchedule()
+        for i in range(7):
+            day_schedule = DaySchedule(
+                enabled=self._day_vars[i].get(),
+                start_time=self._start_vars[i].get(),
+                stop_time=self._end_vars[i].get(),
+            )
+            updated_schedule.set_day(i, day_schedule)
+
+        self._result = Settings(
+            idle_threshold_seconds=threshold_value,
+            auto_start=self._autostart_var.get(),
+            monitoring_enabled=self._settings.monitoring_enabled,
+            schedule=updated_schedule,
+        )
+        self._dialog.destroy()
+
+    def _on_cancel(self) -> None:
+        self._result = None
+        self._dialog.destroy()
+
+    def _on_reset(self) -> None:
+        default_schedule = WeeklySchedule()
+        for i in range(7):
+            day_schedule = default_schedule.get_day(i)
+            self._day_vars[i].set(day_schedule.enabled)
+            self._start_vars[i].set(day_schedule.start_time)
+            self._end_vars[i].set(day_schedule.stop_time)
+
+    def show(self) -> Optional[Settings]:
+        self._dialog.mainloop()
+        return self._result
 
 
 class ThresholdDialog:
@@ -444,6 +694,33 @@ def show_schedule_dialog(schedule: Optional[WeeklySchedule] = None) -> Optional[
     thread.start()
     thread.join()
     
+    return result[0]
+
+
+def show_configuration_dialog(
+    settings: Settings,
+    autostart_enabled: bool,
+) -> Optional[Settings]:
+    """
+    Show unified configuration dialog.
+
+    Args:
+        settings: Current settings
+        autostart_enabled: Current autostart registry state
+
+    Returns:
+        Updated settings or None if cancelled.
+    """
+    result: list[Optional[Settings]] = [None]
+
+    def run_dialog():
+        dialog = ConfigurationDialog(None, settings, autostart_enabled)
+        result[0] = dialog.show()
+
+    thread = threading.Thread(target=run_dialog)
+    thread.start()
+    thread.join()
+
     return result[0]
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -18,8 +18,7 @@ def _build_app(monkeypatch, *,
                save_result: bool = True,
                autostart_enabled: bool = False,
                autostart_set_result: bool = True,
-               threshold_result: Optional[int] = None,
-               schedule_result: Optional[WeeklySchedule] = None):
+               configuration_result: Optional[Settings] = None):
     errors: list[tuple[str, str]] = []
 
     class FakeSettingsManager:
@@ -71,6 +70,13 @@ def _build_app(monkeypatch, *,
         def is_within_schedule(self, check_time=None):
             return True
 
+        def get_current_day_schedule(self):
+            return self._schedule.get_day(0)
+
+        @staticmethod
+        def get_day_name(day_index):
+            return "Monday"
+
     class FakeAutoStartManager:
         def __init__(self):
             self.last_set_enabled = None
@@ -88,6 +94,8 @@ def _build_app(monkeypatch, *,
             self.threshold = None
             self.monitoring_enabled = None
             self.active = None
+            self.within_schedule = None
+            self.schedule_label = None
 
         def set_autostart(self, enabled):
             self.autostart_enabled = enabled
@@ -97,6 +105,10 @@ def _build_app(monkeypatch, *,
 
         def set_monitoring(self, is_monitoring):
             self.monitoring_enabled = is_monitoring
+
+        def set_schedule_status(self, within_schedule, schedule_label):
+            self.within_schedule = within_schedule
+            self.schedule_label = schedule_label
 
         def set_active(self, is_active):
             self.active = is_active
@@ -110,8 +122,8 @@ def _build_app(monkeypatch, *,
         def set_on_configure_schedule(self, callback):
             self.on_configure_schedule = callback
 
-        def set_on_toggle_autostart(self, callback):
-            self.on_toggle_autostart = callback
+        def set_on_configure(self, callback):
+            self.on_configure = callback
 
         def set_on_exit(self, callback):
             self.on_exit = callback
@@ -125,11 +137,8 @@ def _build_app(monkeypatch, *,
     def fake_show_error(title, message):
         errors.append((title, message))
 
-    def fake_show_threshold_dialog(current_value):
-        return threshold_result
-
-    def fake_show_schedule_dialog(schedule):
-        return schedule_result
+    def fake_show_configuration_dialog(current_settings, current_autostart):
+        return configuration_result
 
     monkeypatch.setattr(app_module, "SettingsManager", FakeSettingsManager)
     monkeypatch.setattr(app_module, "IdleDetector", FakeIdleDetector)
@@ -138,8 +147,7 @@ def _build_app(monkeypatch, *,
     monkeypatch.setattr(app_module, "AutoStartManager", FakeAutoStartManager)
     monkeypatch.setattr(app_module, "TrayIcon", FakeTrayIcon)
     monkeypatch.setattr(app_module, "show_error", fake_show_error)
-    monkeypatch.setattr(app_module, "show_threshold_dialog", fake_show_threshold_dialog)
-    monkeypatch.setattr(app_module, "show_schedule_dialog", fake_show_schedule_dialog)
+    monkeypatch.setattr(app_module, "show_configuration_dialog", fake_show_configuration_dialog)
 
     app = app_module.MoMoApp()
     return app, errors
@@ -188,69 +196,56 @@ def test_monitoring_toggle_save_failure_still_toggles(monkeypatch):
     assert len(errors) == 1
 
 
-def test_configure_threshold_save_failure_still_updates(monkeypatch):
-    settings = Settings()
-    app, errors = _build_app(
-        monkeypatch,
-        settings=settings,
-        save_result=False,
-        threshold_result=600
-    )
-
-    app._on_configure_threshold()
-
-    assert app._settings.idle_threshold_seconds == 600
-    assert app._idle_detector.threshold_seconds == 600
-    assert app._tray_icon.threshold == 600
-    assert len(errors) == 1
-
-
-def test_configure_schedule_save_failure_still_updates(monkeypatch):
+def test_configure_save_failure_still_updates(monkeypatch):
     settings = Settings()
     new_schedule = WeeklySchedule()
     new_schedule.monday.start_time = "09:00"
-
-    app, errors = _build_app(
-        monkeypatch,
-        settings=settings,
-        save_result=False,
-        schedule_result=new_schedule
+    configuration_result = Settings(
+        idle_threshold_seconds=600,
+        auto_start=True,
+        monitoring_enabled=settings.monitoring_enabled,
+        schedule=new_schedule
     )
 
-    app._on_configure_schedule()
-
-    assert app._schedule_manager.schedule is new_schedule
-    assert len(errors) == 1
-
-
-def test_autostart_toggle_success_save_failure(monkeypatch):
-    settings = Settings(auto_start=False)
     app, errors = _build_app(
         monkeypatch,
         settings=settings,
         save_result=False,
         autostart_enabled=False,
-        autostart_set_result=True
+        autostart_set_result=True,
+        configuration_result=configuration_result
     )
 
-    app._on_autostart_toggled(True)
+    app._on_configure()
 
-    assert app._settings.auto_start is True
+    assert app._settings.idle_threshold_seconds == 600
+    assert app._idle_detector.threshold_seconds == 600
+    assert app._tray_icon.threshold == 600
+    assert app._schedule_manager.schedule is new_schedule
     assert app._tray_icon.autostart_enabled is True
     assert len(errors) == 1
 
 
-def test_autostart_toggle_failure_reverts_tray(monkeypatch):
+def test_configure_autostart_toggle_failure_reverts(monkeypatch):
     settings = Settings(auto_start=False)
+    configuration_result = Settings(
+        idle_threshold_seconds=settings.idle_threshold_seconds,
+        auto_start=True,
+        monitoring_enabled=settings.monitoring_enabled,
+        schedule=settings.schedule
+    )
+
     app, errors = _build_app(
         monkeypatch,
         settings=settings,
         save_result=True,
         autostart_enabled=False,
-        autostart_set_result=False
+        autostart_set_result=False,
+        configuration_result=configuration_result
     )
 
-    app._on_autostart_toggled(True)
+    app._on_configure()
 
+    assert app._settings.auto_start is False
     assert app._tray_icon.autostart_enabled is False
     assert len(errors) == 1

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -72,7 +72,7 @@ class TestScheduleManager:
     
     def test_is_within_schedule_just_after_end(self):
         """Test detection just after end time."""
-        manager = ScheduleManager()
+        manager = schedule_module.ScheduleManager()
         
         # Monday at 5:01 PM
         test_time = datetime(2026, 1, 19, 17, 1)


### PR DESCRIPTION
## Summary
- Combine idle threshold, schedule, and startup settings into a single modern configuration dialog.
- Replace tray menu items with a single Configuration… entry.
- Make tray monitoring label reflect schedule state (disabled outside window).
- Keep monitoring auto-start behavior aligned with schedule updates.

## Testing
- pytest tests/test_app.py tests/test_schedule.py

## Notes
- UI title now reads "MoMo - Mouse Mover" as requested.
